### PR TITLE
Fix failing CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,19 +19,19 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -66,19 +66,19 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -87,7 +87,7 @@ jobs:
         run: cargo build --release --verbose
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_path }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jeb"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "async-stream",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeb"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,13 +164,12 @@ impl KeyOrderOptions {
     fn apply_to_value(&self, value: &Value) -> Value {
         match value {
             Value::Object(obj) => {
-                let index_map: JsonObject = obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                let index_map: JsonObject =
+                    obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
                 let reordered = self.apply(&index_map);
                 Value::Object(reordered.into_iter().collect())
             }
-            Value::Array(arr) => {
-                Value::Array(arr.iter().map(|v| self.apply_to_value(v)).collect())
-            }
+            Value::Array(arr) => Value::Array(arr.iter().map(|v| self.apply_to_value(v)).collect()),
             _ => value.clone(),
         }
     }
@@ -568,10 +567,14 @@ fn merge_objects(objects: &[JsonObject]) -> Result<JsonObject, String> {
                     match (existing_value, value) {
                         (Value::Object(existing_obj), Value::Object(new_obj)) => {
                             // Recursively merge objects
-                            let existing_map: JsonObject =
-                                existing_obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                            let new_map: JsonObject =
-                                new_obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                            let existing_map: JsonObject = existing_obj
+                                .iter()
+                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .collect();
+                            let new_map: JsonObject = new_obj
+                                .iter()
+                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .collect();
 
                             match merge_objects(&[existing_map, new_map]) {
                                 Ok(merged) => {
@@ -1053,10 +1056,7 @@ Random text in between
             json_total_order(&json!(false), &json!(null)),
             Ordering::Less
         );
-        assert_eq!(
-            json_total_order(&json!(null), &json!(true)),
-            Ordering::Less
-        );
+        assert_eq!(json_total_order(&json!(null), &json!(true)), Ordering::Less);
         assert_eq!(json_total_order(&json!(true), &json!({})), Ordering::Less);
     }
 


### PR DESCRIPTION
- Update actions/upload-artifact from v3 to v4 (deprecated as of April 2024)
- Update actions/cache from v3 to v4 for consistency and latest features