### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests and Native Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jeremyBanks/json-entity-bucket/security/code-scanning/7](https://github.com/jeremyBanks/json-entity-bucket/security/code-scanning/7)

**General fix:**  
Add an explicit `permissions:` block with the minimal required privileges at the workflow level. Since none of these jobs (tests, lint, format, build) appear to need write access to the repository or any resources, `contents: read` is the safest baseline, and is what GitHub and CodeQL recommend.

**Detailed steps:**  
Insert a `permissions: contents: read` block after the workflow `name:` and before `on:`. This will apply least-privilege permissions to all jobs in the workflow unless individually overridden later.  
No changes of logic or structure are needed—this is purely declarative YAML.

**Files/regions/lines:**  
Edit `.github/workflows/test.yml`, inserting the following lines after the workflow `name: Tests and Native Build`.

**Requirements:**  
No new methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
