### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,4 +1,6 @@
 name: Version Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jeremyBanks/json-entity-bucket/security/code-scanning/6](https://github.com/jeremyBanks/json-entity-bucket/security/code-scanning/6)

The best way to fix this issue is to add a `permissions:` block that restricts the GITHUB_TOKEN’s privileges as much as possible, without breaking functionality. Since the job only checks out code and runs a shell script, it requires only read access to repository contents (`contents: read`). This key should be placed either at the workflow root—applying to all jobs—or specifically to the `check-version` job. Placing it at the root is more concise for single-job workflows. The only region to change is the top of the file, by inserting the `permissions:` key beneath the `name:` field and above the `on:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
